### PR TITLE
Use Git for Windows instead of Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `sudo apt-get install git`
 
-### On Windows(7 or later) - https://desktop.github.com/
+### On Windows(7 or later) - https://github.com/git-for-windows/git/releases/
 
 ### Configure :
 


### PR DESCRIPTION
I think it's best to use the git for windows client instead of the github one as it's the closest match to the Linux git client.
